### PR TITLE
chore/upgrade Greenwood v0.32.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN --mount=type=bind,source=package.json,target=package.json \
     npm ci --omit=dev
 
 # custom install the Greenwood CLI for running the server
-RUN npm i @greenwood/cli@alpha
+RUN npm i @greenwood/cli@${GREENWOOD_VERSION}
 
 ################################################################################
 # Create a stage for building the application.

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN --mount=type=bind,source=package.json,target=package.json \
     npm ci --omit=dev
 
 # custom install the Greenwood CLI for running the server
-RUN npm i @greenwood/cli@${GREENWOOD_VERSION}
+RUN npm i @greenwood/cli@alpha
 
 ################################################################################
 # Create a stage for building the application.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,16 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@greenwood/cli": "~0.32.0-alpha.8",
+        "@greenwood/cli": "~0.32.0-alpha.9",
         "rimraf": "^6.0.0"
       }
     },
     "node_modules/@greenwood/cli": {
-      "version": "0.32.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.32.0-alpha.8.tgz",
-      "integrity": "sha512-VArE4iUcKfXA46Wra7ADZqRfRTDvxHcNP2WmKS1H38ITstwHM9gykI1tvpQpait2667bEebzrrC4JwjiJqivSg==",
+      "version": "0.32.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.32.0-alpha.9.tgz",
+      "integrity": "sha512-+J228CKd9yzBrAOgF2CfNRd4Ups2jFp/wv3BQ29cZTqOWVuRf3Tx8+MxhPzF9R8Oq/4qgHI4vRYDIQyIRAy+aA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@rollup/plugin-commonjs": "^28.0.0",
         "@rollup/plugin-node-resolve": "^15.0.0",
@@ -41,7 +42,7 @@
         "rollup": "^4.26.0",
         "sucrase": "^3.35.0",
         "unified": "^11.0.5",
-        "wc-compiler": "~0.16.0"
+        "wc-compiler": "~0.17.0"
       },
       "bin": {
         "greenwood": "src/index.js"
@@ -130,6 +131,7 @@
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -140,6 +142,7 @@
       "resolved": "https://registry.npmjs.org/@projectevergreen/acorn-jsx-esm/-/acorn-jsx-esm-0.1.0.tgz",
       "integrity": "sha512-ZBSkr0e2M4ylq74dTGHSkWI2dF3Mz8zwBLyzIXZMftecKDADcsCTj7bWltVgtdl8Rh4+bmY1jNWUw7AlSV/r7A==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -768,6 +771,7 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -824,7 +828,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -850,6 +855,7 @@
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
       "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "astring": "bin/astring"
       }
@@ -1688,6 +1694,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -2270,6 +2277,7 @@
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -2427,7 +2435,8 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/list-item": {
       "version": "1.1.1",
@@ -2541,7 +2550,8 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/magic-string": {
       "version": "0.30.17",
@@ -3231,6 +3241,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -3295,6 +3306,7 @@
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -3333,6 +3345,7 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3438,6 +3451,7 @@
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -3462,10 +3476,11 @@
       }
     },
     "node_modules/pirates": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
-      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
@@ -4155,6 +4170,7 @@
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
       "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
@@ -4177,6 +4193,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
@@ -4216,6 +4233,7 @@
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
       }
@@ -4225,6 +4243,7 @@
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
@@ -4331,7 +4350,8 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -4524,10 +4544,11 @@
       }
     },
     "node_modules/wc-compiler": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.16.0.tgz",
-      "integrity": "sha512-1UngRtP8cA8HFFR1O8JDPz7rCmdeAq5gYoEhuuwqCgnhW37QGhAkq/fuG6CKMB5D+R4zI5mzkkIHk1ZAQ41YTg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.17.0.tgz",
+      "integrity": "sha512-08d31qhYjlJiTEfTEW3kpSdcNnx0j0eGaUIA1/+oyczJCxya7+tvbQ/Tz3wbS2kzd/t8iSxNYdfhpf43o6RVuA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@projectevergreen/acorn-jsx-esm": "~0.1.0",
         "acorn": "^8.14.0",
@@ -4537,7 +4558,7 @@
         "sucrase": "^3.35.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/web-namespaces": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@greenwood/cli": "~0.32.0-alpha.9",
+        "@greenwood/cli": "~0.32.0",
         "rimraf": "^6.0.0"
       }
     },
     "node_modules/@greenwood/cli": {
-      "version": "0.32.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.32.0-alpha.9.tgz",
-      "integrity": "sha512-+J228CKd9yzBrAOgF2CfNRd4Ups2jFp/wv3BQ29cZTqOWVuRf3Tx8+MxhPzF9R8Oq/4qgHI4vRYDIQyIRAy+aA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.32.0.tgz",
+      "integrity": "sha512-8n4ja1ZTDho29JTv+ZjCTOVlB36YT0Uo4XmN/zp/tleprE5/Y1olwWD2gi9zLMyPRIzez6X7wyNwPEj8Eu+rQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,15 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@greenwood/cli": "~0.31.0",
+        "@greenwood/cli": "~0.32.0-alpha.8",
         "rimraf": "^6.0.0"
       }
     },
     "node_modules/@greenwood/cli": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.31.0.tgz",
-      "integrity": "sha512-fkkN0HNHFsbafcBSGn+LfHtoy+NiApnyw+p/hushZzRLCi7XqS4DH2C/0Tr2pIABWWurm4M1o2hGy9OyHMKV1g==",
+      "version": "0.32.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.32.0-alpha.8.tgz",
+      "integrity": "sha512-VArE4iUcKfXA46Wra7ADZqRfRTDvxHcNP2WmKS1H38ITstwHM9gykI1tvpQpait2667bEebzrrC4JwjiJqivSg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@rollup/plugin-commonjs": "^28.0.0",
         "@rollup/plugin-node-resolve": "^15.0.0",
@@ -40,6 +39,7 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.1",
         "rollup": "^4.26.0",
+        "sucrase": "^3.35.0",
         "unified": "^11.0.5",
         "wc-compiler": "~0.16.0"
       },
@@ -47,7 +47,7 @@
         "greenwood": "src/index.js"
       },
       "engines": {
-        "node": "^18.20.5 || ^20.10.0 || ^22.12.0"
+        "node": "^18.20.5 || ^20.18.3 || >=22.12.0"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "start": "npm run serve"
   },
   "devDependencies": {
-    "@greenwood/cli": "~0.32.0-alpha.8",
+    "@greenwood/cli": "~0.32.0-alpha.9",
     "rimraf": "^6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "start": "npm run serve"
   },
   "devDependencies": {
-    "@greenwood/cli": "~0.32.0-alpha.9",
+    "@greenwood/cli": "~0.32.0",
     "rimraf": "^6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "start": "npm run serve"
   },
   "devDependencies": {
-    "@greenwood/cli": "~0.31.0",
+    "@greenwood/cli": "~0.32.0-alpha.8",
     "rimraf": "^6.0.0"
   }
 }


### PR DESCRIPTION
https://github.com/ProjectEvergreen/greenwood/issues/1414

## TODO
1. [x] revert hardcoded Greenwood version in _Dockerfile_ for GA release